### PR TITLE
最新の挙動に合わせてREADMEを更新しました

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ Runner registered successfully. Feel free to start it, but if it's running alrea
 
 このデモではCI Runnerが動作するサーバでCIを実行するのでexecutoreには`shell`を指定する。
 
+指定したタグは、該当するプロジェクトのRunnersページで確認できる。
+
 ### myappプロジェクトにコードをpush
 
 プロジェクトのルートに`.gitlab-ci.yml`を配置してコードをリポジトリにpushする。

--- a/README.md
+++ b/README.md
@@ -32,12 +32,6 @@ GitLabに`myapp`プロジェクトを作成する。
 
 e.g.) http://192.168.133.10/myuser/myapp
 
-### myappプロジェクトでGitLab CIサービスを有効化
-
-プロジェクトのページから Settings > Services > GitLab CI を辿り、GitLab CIを有効にする。
-
-e.g.) http://192.168.133.10/myuser/myapp/services/gitlab_ci/edit
-
 ### GitLab Runnerの設定
 
 GitLab Runnerサーバで下記のコマンドでCIサーバを登録する。
@@ -48,18 +42,24 @@ e.g.) http://192.168.133.10/ci/projects/1/runners
 
 ```
 $ vagrant ssh runner
-Welcome to your Packer-built virtual machine.
+----------------------------------------------------------------
+  CentOS 7.1.1503                             built 2016-01-08
+----------------------------------------------------------------
 [vagrant@localhost ~]$ sudo gitlab-runner register
-Please enter the gitlab-ci coordinator URL (e.g. http://gitlab-ci.org:3000/):
+Running in system-mode.
+
+Please enter the gitlab-ci coordinator URL (e.g. https://gitlab.com/ci):
 http://192.168.133.10/ci
 Please enter the gitlab-ci token for this runner:
 ea0aeb7b24bdb177953d4226f4028e
 Please enter the gitlab-ci description for this runner:
 [localhost.localdomain]: ci-runner-01
-INFO[0053] ea0aeb7b Registering runner... succeeded
-Please enter the executor: ssh, shell, parallels, docker, docker-ssh:
-[shell]:
-INFO[0059] Runner registered successfully. Feel free to start it, but if it's running already the config should be automatically reloaded!
+Please enter the gitlab-ci tags for this runner (comma separated):
+example,vagrant,perl
+Registering runner... succeeded                     runner=3LMx5gEX
+Please enter the executor: ssh, shell, parallels, docker, docker-ssh, virtualbox:
+shell
+Runner registered successfully. Feel free to start it, but if it's running already the config should be automatically reloaded!
 [vagrant@localhost ~]$ exit
 ```
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ $ git push -u origin master
 
 ### CIの確認
 
-プロジェクトのページ(e.g. http://192.168.133.10/myuser/myapp)から`Continuous Integration`を辿り、CIの結果を確認する。
+プロジェクトのページ(e.g. http://192.168.133.10/myuser/myapp )から`Continuous Integration`を辿り、CIの結果を確認する。
 
 e.g.) http://192.168.133.10/ci/projects/1/builds/1
 


### PR DESCRIPTION
- GitLab Community Edition 8.4.4 9c31cc6
- gitlab-runner version 1.0.4 (014aa8c)

上記のバージョンになっている2016.2.22現在で試してみたところ、READMEの手順と変わったところがありました。

次の点について、READMEのメンテを行いましたのでご確認ください。
1. GitlabCIサービスの有効化が必要なくなりました
   - .gitlab-ci.ymlが入ったコミットをプッシュすれば自動で有効になるようです
2. runnerをregisterする際の対話内容が変わりました
   - タグを訊かれるようになりました
     - タグの確認方法についても別途追記しました
   - executorにデフォルトの選択肢がなくなったため、`shell`を明示的に指定しました
   - その他、メッセージのマイナーチェンジを反映しました
